### PR TITLE
Sd2 43562

### DIFF
--- a/resources/js/components/feature/company/CompaniesDataTable.vue
+++ b/resources/js/components/feature/company/CompaniesDataTable.vue
@@ -5,6 +5,9 @@ import { Link, usePage } from '@inertiajs/vue3'
 import { FlexRender, getCoreRowModel, useVueTable } from '@tanstack/vue-table'
 import { h, reactive } from 'vue'
 
+import { useHasPermissions } from '@/composables/hooks/auth/useHasPermissions'
+const { hasPermissions } = useHasPermissions()
+
 import { Button } from '@/components/ui/button'
 import {
   Table,
@@ -60,28 +63,30 @@ const columns = [
       })
     },
   },
-  {
-    accessorKey: `edit`,
-    header: () => h(`div`, { class: `text-sm font-semibold` }, `Edit`),
-    cell: ({ row }) => {
-      return h(
-        Button,
-        { variant: `outline`, size: `sm`, asChild: true },
-        {
-          default: () =>
-            h(
-              Link,
-              { href: route(`admin.company.show`, row.original.uuid) },
-              {
-                default: () =>
-                  h(FontAwesomeIcon, { icon: faEdit, fixedWidth: true }),
-              },
-            ),
+  hasPermissions(`company.edit`)
+    ? {
+        accessorKey: `edit`,
+        header: () => h(`div`, { class: `text-sm font-semibold` }, `Edit`),
+        cell: ({ row }) => {
+          return h(
+            Button,
+            { variant: `outline`, size: `sm`, asChild: true },
+            {
+              default: () =>
+                h(
+                  Link,
+                  { href: route(`admin.company.show`, row.original.uuid) },
+                  {
+                    default: () =>
+                      h(FontAwesomeIcon, { icon: faEdit, fixedWidth: true }),
+                  },
+                ),
+            },
+          )
         },
-      )
-    },
-  },
-]
+      }
+    : null,
+].filter(Boolean)
 
 const tableOptions = reactive({
   get data() {

--- a/resources/js/components/feature/company/CompanyDestroyDialog.vue
+++ b/resources/js/components/feature/company/CompanyDestroyDialog.vue
@@ -16,7 +16,9 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { useCompanyDestroyMutation } from '@/composables/mutations/company'
+import { useHasPermissions } from '@/composables/hooks/auth/useHasPermissions'
 
+const { hasPermissions } = useHasPermissions()
 const props = defineProps({
   company: {
     type: Object,
@@ -51,13 +53,14 @@ const cancelDialog = () => {
 
 <template>
   <Dialog v-model:open="isOpen">
-    <DialogTrigger as-child>
-      <Button variant="destructive" size="sm">
-        <FontAwesomeIcon class="mr-2" :icon="faTrashAlt" fixed-width />
-
-        <span>Delete</span>
-      </Button>
-    </DialogTrigger>
+    <template v-if="hasPermissions('company.delete')">
+      <DialogTrigger as-child>
+        <Button variant="destructive" size="sm">
+          <FontAwesomeIcon class="mr-2" :icon="faTrashAlt" fixed-width />
+          <span>Delete</span>
+        </Button>
+      </DialogTrigger>
+    </template>
 
     <DialogContent>
       <DialogHeader>

--- a/resources/js/components/feature/company/CompanyInfoCell.vue
+++ b/resources/js/components/feature/company/CompanyInfoCell.vue
@@ -18,6 +18,9 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { imageAssetUrl } from '@/composables/hooks/disks'
+import { useHasPermissions } from '@/composables/hooks/auth/useHasPermissions'
+
+const { hasPermissions } = useHasPermissions()
 
 defineProps({
   company: {
@@ -71,18 +74,21 @@ defineProps({
 
       <HoverCard :open-delay="300">
         <HoverCardTrigger as-child>
-          <Button variant="link" class="p-0 underline" as-child>
-            <Link :href="route(`admin.company.show`, company.uuid)">
-              {{ company.name }}
-            </Link>
-          </Button>
+          <template v-if="hasPermissions('company.read')">
+            <Button variant="link" class="p-0 underline" as-child>
+              <Link :href="route('admin.company.show', company.uuid)">
+                {{ company.name }}
+              </Link>
+            </Button>
+          </template>
+          <template v-else>
+            {{ company.name }}
+          </template>
         </HoverCardTrigger>
-
         <HoverCardContent class="w-[28rem]" align="start">
           <div class="flex flex-col items-start justify-start gap-4">
             <div class="flex w-full flex-row justify-between gap-1">
               <h4 class="text-xl font-semibold">{{ company.name }}</h4>
-
               <Badge v-if="company.pipeline_company_id" variant="secondary">
                 Pipeline ID: {{ company.pipeline_company_id }}
               </Badge>

--- a/resources/js/components/feature/theme/ThemeCreateButton.vue
+++ b/resources/js/components/feature/theme/ThemeCreateButton.vue
@@ -4,11 +4,17 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { Link } from '@inertiajs/vue3'
 
 import { Button } from '@/components/ui/button'
+import { useHasPermissions } from '@/composables/hooks/auth/useHasPermissions'
+
+const { hasPermissions } = useHasPermissions()
 </script>
 
 <template>
   <Button variant="default" as-child size="sm">
-    <Link :href="route('admin.theme.create')">
+    <Link
+      v-if="hasPermissions('theme.create')"
+      :href="route('admin.theme.create')"
+    >
       <FontAwesomeIcon :icon="faPlus" class="mr-2" fixed-width />
 
       <span>Create Theme</span></Link

--- a/resources/js/components/feature/theme/ThemeDestroyDialog.vue
+++ b/resources/js/components/feature/theme/ThemeDestroyDialog.vue
@@ -4,6 +4,8 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { router } from '@inertiajs/vue3'
 import { useQueryClient } from '@tanstack/vue-query'
 import { ref } from 'vue'
+import { useHasPermissions } from '@/composables/hooks/auth/useHasPermissions'
+const { hasPermissions } = useHasPermissions()
 
 import { Button } from '@/components/ui/button'
 import {
@@ -51,13 +53,15 @@ const cancelDialog = () => {
 
 <template>
   <Dialog v-model:open="isOpen">
-    <DialogTrigger as-child>
-      <Button variant="destructive" size="sm">
-        <FontAwesomeIcon class="mr-2" :icon="faTrashAlt" fixed-width />
+    <template v-if="hasPermissions('theme.delete')">
+      <DialogTrigger as-child>
+        <Button variant="destructive" size="sm">
+          <FontAwesomeIcon class="mr-2" :icon="faTrashAlt" fixed-width />
 
-        <span>Delete</span>
-      </Button>
-    </DialogTrigger>
+          <span>Delete</span>
+        </Button>
+      </DialogTrigger>
+    </template>
 
     <DialogContent>
       <DialogHeader>

--- a/resources/js/components/feature/userManagement/UserManagementTable.vue
+++ b/resources/js/components/feature/userManagement/UserManagementTable.vue
@@ -3,6 +3,8 @@ import { usePage } from '@inertiajs/vue3'
 import { FlexRender, getCoreRowModel, useVueTable } from '@tanstack/vue-table'
 import { h, reactive } from 'vue'
 
+import { useHasPermissions } from '@/composables/hooks/auth/useHasPermissions'
+const { hasPermissions } = useHasPermissions()
 import UserRolesDropdown from '@/components/feature/userManagement/UserRolesDropdown.vue'
 import {
   Table,
@@ -56,20 +58,21 @@ const columns = [
       )
     },
   },
-  {
-    accessorKey: `edit`,
-    header: () => h(`div`, { class: `text-sm font-semibold` }, `Edit`),
-    cell: ({ row }) => {
-      return h(UserRolesDropdown, {
-        userId: row.original.id,
-        onRoleUpdated: (newRole) => {
-          // call your update function here
-          updateUserRole(row.original.id, newRole, row)
+  hasPermissions(`role.update`)
+    ? {
+        accessorKey: `edit`,
+        header: () => h(`div`, { class: `text-sm font-semibold` }, `Edit`),
+        cell: ({ row }) => {
+          return h(UserRolesDropdown, {
+            userId: row.original.id,
+            onRoleUpdated: (newRole) => {
+              updateUserRole(row.original.id, newRole, row)
+            },
+          })
         },
-      })
-    },
-  },
-]
+      }
+    : null,
+].filter(Boolean)
 
 const tableOptions = reactive({
   get data() {

--- a/resources/js/components/layout/navigation/AuthenticatedNavbar.vue
+++ b/resources/js/components/layout/navigation/AuthenticatedNavbar.vue
@@ -17,6 +17,9 @@ import {
   navigationMenuTriggerStyle,
 } from '@/components/ui/navigation-menu'
 
+import { useHasPermissions } from '@/composables/hooks/auth/useHasPermissions'
+const { hasPermissions } = useHasPermissions()
+
 const {
   auth: { user },
 } = usePage().props
@@ -67,6 +70,7 @@ const {
                 <li>
                   <NavigationMenuLink as-child>
                     <Link
+                      v-if="hasPermissions('theme.read')"
                       :href="route(`admin.theme.index`)"
                       class="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
                     >

--- a/resources/js/pages/admin/theme/Index.vue
+++ b/resources/js/pages/admin/theme/Index.vue
@@ -6,7 +6,9 @@ import AuthenticatedLayout from '@/components/layout/page/AuthenticatedLayout.vu
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { useThemesQuery } from '@/composables/queries/theme'
+import { useHasPermissions } from '@/composables/hooks/auth/useHasPermissions'
 
+const { hasPermissions } = useHasPermissions()
 const { initialThemes } = usePage().props
 
 const { data: themes, isError } = useThemesQuery({
@@ -53,7 +55,11 @@ const { data: themes, isError } = useThemesQuery({
             class="ml-auto flex w-full flex-row items-center justify-end space-x-4"
           >
             <Button as-child variant="outline" size="sm">
-              <Link :href="`/admin/themes/${theme.uuid}`">Edit</Link>
+              <Link
+                v-if="hasPermissions('theme.update')"
+                :href="`/admin/themes/${theme.uuid}`"
+                >Edit</Link
+              >
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## **CodeAnt-AI Description**
- Added granular permission checks across multiple components to control the visibility of action buttons and links (Edit, Delete, Create) for companies, themes, and user management features.
- Integrated the `useHasPermissions` composable in all relevant components to centralize permission logic.
- Updated data tables and navigation menus to conditionally render columns and links based on user permissions.
- Ensured that UI elements for sensitive actions are only shown to users with the appropriate permissions, improving security and user experience.

This PR introduces a comprehensive permission-based UI control system for company, theme, and user management features. By leveraging a centralized permission composable, it ensures that only authorized users can see and interact with critical actions, enhancing both security and usability throughout the application.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CompaniesDataTable.vue</strong><dd><code>Conditional rendering of Edit column based on permissions in <br>CompaniesDataTable</code></dd></summary>
<hr>

resources/js/components/feature/company/CompaniesDataTable.vue
<li>Added permission check for displaying the "Edit" column and button <br>based on <code>company.edit</code> permission.<br> <li> Utilized <code>useHasPermissions</code> composable to conditionally render edit <br>actions.<br> <li> Filtered columns to exclude null entries.<br>


</details>


  </td>
  <td><a href="https://github.com/prologuetechnology/tracking/pull/25/files#diff-65d8115d2d33e2e8a59aef1eeb8a7374c3a006fbc28306b7932343b1d20ce44a">+26/-21</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>CompanyDestroyDialog.vue</strong><dd><code>Permission-based display of company delete dialog trigger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/components/feature/company/CompanyDestroyDialog.vue
<li>Wrapped the delete button and dialog trigger in a permission check for <br><code>company.delete</code>.<br> <li> Integrated <code>useHasPermissions</code> composable for permission logic.<br>


</details>


  </td>
  <td><a href="https://github.com/prologuetechnology/tracking/pull/25/files#diff-31fcedd31abb75d1c7d5a0a07086000d39746f03d1d66e1b51605dcf622c8a01">+10/-7</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>CompanyInfoCell.vue</strong><dd><code>Conditional company name linking based on read permissions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/components/feature/company/CompanyInfoCell.vue
<li>Added permission check for linking company name to details page using <br><code>company.read</code>.<br> <li> Displayed company name as plain text if permission is missing.<br> <li> Used <code>useHasPermissions</code> composable for permission logic.<br>


</details>


  </td>
  <td><a href="https://github.com/prologuetechnology/tracking/pull/25/files#diff-b7038735c8b47b93fa14acc6c968c00b212ee4e5e7515b557be9df09bd55eec6">+13/-7</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ThemeCreateButton.vue</strong><dd><code>Permission-controlled rendering of Create Theme button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/components/feature/theme/ThemeCreateButton.vue
<li>Added permission check for displaying the "Create Theme" button using <br><code>theme.create</code>.<br> <li> Integrated <code>useHasPermissions</code> composable for permission logic.<br>


</details>


  </td>
  <td><a href="https://github.com/prologuetechnology/tracking/pull/25/files#diff-eaedfeb03ee98c1ea793d591ea852ea458f5bbfdcc65b671b5be10a0541acd14">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ThemeDestroyDialog.vue</strong><dd><code>Permission-based display of theme delete dialog trigger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/components/feature/theme/ThemeDestroyDialog.vue
<li>Wrapped the delete button and dialog trigger in a permission check for <br><code>theme.delete</code>.<br> <li> Utilized <code>useHasPermissions</code> composable for permission logic.<br>


</details>


  </td>
  <td><a href="https://github.com/prologuetechnology/tracking/pull/25/files#diff-e3438e53399f5ca52c00fa39309b97974ff89077b175a05a6aa61fcf0b53580f">+10/-6</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>UserManagementTable.vue</strong><dd><code>Conditional rendering of Edit column in UserManagementTable based on <br>permissions</code></dd></summary>
<hr>

resources/js/components/feature/userManagement/UserManagementTable.vue
<li>Added permission check for displaying the "Edit" column and user role <br>dropdown based on <code>role.update</code>.<br> <li> Used <code>useHasPermissions</code> composable for permission logic.<br> <li> Filtered columns to exclude null entries.<br>


</details>


  </td>
  <td><a href="https://github.com/prologuetechnology/tracking/pull/25/files#diff-fbe22c43cc10c235f6fba4fd82301ac7eeb56c2e298709e9e9787549f062ebc5">+16/-13</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>AuthenticatedNavbar.vue</strong><dd><code>Permission-based navigation link rendering in AuthenticatedNavbar</code></dd></summary>
<hr>

resources/js/components/layout/navigation/AuthenticatedNavbar.vue
<li>Added permission check for displaying the "Themes" link in the <br>navigation menu using <code>theme.read</code>.<br> <li> Integrated <code>useHasPermissions</code> composable for permission logic.<br>


</details>


  </td>
  <td><a href="https://github.com/prologuetechnology/tracking/pull/25/files#diff-0d80242cf9da65f104b9cf95a6ebe416c9272421311b56804cbc4564b17b856c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Index.vue</strong><dd><code>Permission-controlled rendering of Edit button in Theme Index page</code></dd></summary>
<hr>

resources/js/pages/admin/theme/Index.vue
<li>Added permission check for displaying the "Edit" button for themes <br>using <code>theme.update</code>.<br> <li> Integrated <code>useHasPermissions</code> composable for permission logic.<br>


</details>


  </td>
  <td><a href="https://github.com/prologuetechnology/tracking/pull/25/files#diff-1bc645df1c2dab97892757818011815fc0aa502483c402b5ccc5f6dd5cab9564">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
